### PR TITLE
Restrict auto-merge to direct dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,9 @@ updates:
       timezone: "America/New_York"
     open-pull-requests-limit: 10
     
-    # Auto-merge patch updates only for production
-    allow:
-      - dependency-type: "all"
+  # Auto-merge patch updates only for production
+  allow:
+    - dependency-type: "direct"
     
     # Commit message configuration
     commit-message:


### PR DESCRIPTION
Change dependency type to allow only direct dependencies for auto-merge.